### PR TITLE
fix: header width on 2.9.0.beta2

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -153,7 +153,7 @@ header {
 
   .wrap {
     background-color: #06c;
-    max-width: 77rem;
+    max-width: 90rem;
     padding-right: 0.75rem;
     padding-left: 0.75rem;
 


### PR DESCRIPTION
Fix the header being too narrow after the update to Discourse 2.9.0.beta2.